### PR TITLE
Expose the jfx Scene from the JavaFxUI instance

### DIFF
--- a/src/main/java/com/jayfella/jme/jfx/JavaFxUI.java
+++ b/src/main/java/com/jayfella/jme/jfx/JavaFxUI.java
@@ -370,4 +370,10 @@ public class JavaFxUI {
         }
     }
 
+    /**
+     * @return The Scene that the JavaFX UI is running in
+     */
+    public Scene getScene() {
+        return scene;
+    }
 }


### PR DESCRIPTION
It is sometimes useful to be able to access the javafx scene object. 

One example is when getting the width and height of the scene to resize components within the scene. Although the width and height is based on the camera size, it is safer to get the width and height from the scene itself for future proofing. 

This is my only use case at the moment but I am sure there are others. 