### PR TITLE
Combo box jme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/out
+/.gradle

--- a/src/main/java/com/jayfella/jme/jfx/JavaFxUI.java
+++ b/src/main/java/com/jayfella/jme/jfx/JavaFxUI.java
@@ -16,13 +16,16 @@ import javafx.geometry.Bounds;
 import javafx.scene.Group;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.paint.Color;
+import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Vector;
 
 public class JavaFxUI {
 
@@ -37,6 +40,8 @@ public class JavaFxUI {
     private Group group;
     private Scene scene;
     private AnchorPane uiscene;
+
+    Runnable removeExistingPopup = () -> {};
 
     // dialog - overlays an anchorpane to stop clicking background items and allows "darkening" too.
     private AnchorPane dialogAnchorPanel;
@@ -146,6 +151,31 @@ public class JavaFxUI {
             uiscene.getChildren().add(node);
             recursivelyNotifyChildrenAdded(node);
         });
+    }
+
+    public Runnable attachPopup(javafx.scene.Node node, double x, double y){
+        removeExistingPopup.run();
+
+        AnchorPane popupOverlay = new AnchorPane();
+        popupOverlay.setMinWidth(app.getCamera().getWidth());
+        popupOverlay.setMinHeight(app.getCamera().getHeight());
+        popupOverlay.getChildren().add(node);
+
+        node.setTranslateX(x);
+        node.setTranslateY(y);
+
+        group.getChildren().add(popupOverlay);
+
+        removeExistingPopup = () -> {
+            group.getChildren().remove(popupOverlay);
+            removeExistingPopup = () -> {};
+        };
+
+        popupOverlay.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
+            removeExistingPopup.run();
+        });
+
+        return removeExistingPopup;
     }
 
     /**

--- a/src/main/java/com/jayfella/jme/jfx/JavaFxUI.java
+++ b/src/main/java/com/jayfella/jme/jfx/JavaFxUI.java
@@ -153,6 +153,15 @@ public class JavaFxUI {
         });
     }
 
+    /**
+     * Attaches a popup onto the scene in a JME friendly way.
+     * Only one popup ban be onscreen at once, adding annother will remove the old one.
+     * Clicking away from the popup will close it.
+     * @param node The content to be displayed
+     * @param x X coordinate of the top left of the popup
+     * @param y Y coordinate of the top left of the popup
+     * @return A Runnable that if called will remove the popup
+     */
     public Runnable attachPopup(javafx.scene.Node node, double x, double y){
         removeExistingPopup.run();
 
@@ -171,7 +180,7 @@ public class JavaFxUI {
             removeExistingPopup = () -> {};
         };
 
-        popupOverlay.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
+        popupOverlay.addEventHandler(MouseEvent.MOUSE_PRESSED, event -> {
             removeExistingPopup.run();
         });
 

--- a/src/main/java/com/jayfella/jme/jfx/jmealternatives/ComboBoxJME.java
+++ b/src/main/java/com/jayfella/jme/jfx/jmealternatives/ComboBoxJME.java
@@ -1,0 +1,55 @@
+package com.jayfella.jme.jfx.jmealternatives;
+
+import com.jayfella.jme.jfx.JavaFxUI;
+import javafx.geometry.Bounds;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.ListView;
+
+/**
+ * This is a JME alternative for the ComboBox.
+ *
+ * It behaves broadly the same way as the core ComboBox, but is not feature complete.
+ *
+ * In particular:
+ * It doesn't fully support keyboard selection (a mouse click is needed to close it)
+ * It doesn't support sizing based on number of entries, only by pixels
+ * It can go "offscreen" when it tries to open near the bottom of the screen
+ *
+ * @param <T>
+ */
+public class ComboBoxJME<T> extends ComboBox<T> {
+
+    Runnable removeListPopup;
+
+    int maxHeight = 200;
+
+    @Override
+    public void show() {
+        Bounds boundsInScene = localToScene(getBoundsInLocal());
+
+        ListView<T> items = new ListView<>();
+        items.setItems(this.getItems());
+        items.setMinWidth(boundsInScene.getWidth());
+        items.setMaxHeight(maxHeight);
+
+        removeListPopup = JavaFxUI.getInstance().attachPopup(items, boundsInScene.getMinX(), boundsInScene.getMaxY());
+        items.setOnMouseClicked(event -> {
+            getSelectionModel().select(items.getSelectionModel().getSelectedItem());
+            removeListPopup.run();
+        });
+    }
+
+    @Override
+    public void hide() {
+        //do nothing, we're handling our own open/close (although keyboard based selection might need this?)
+    }
+
+    /**
+     * Sets the height of the combobox when it opens (in pixels)
+     * @param height
+     */
+    public void setListHeight(int height){
+        this.maxHeight = height;
+    }
+
+}

--- a/src/main/java/com/jayfella/jme/jfx/jmealternatives/ComboBoxJME.java
+++ b/src/main/java/com/jayfella/jme/jfx/jmealternatives/ComboBoxJME.java
@@ -33,7 +33,8 @@ public class ComboBoxJME<T> extends ComboBox<T> {
         items.setMaxHeight(maxHeight);
 
         removeListPopup = JavaFxUI.getInstance().attachPopup(items, boundsInScene.getMinX(), boundsInScene.getMaxY());
-        items.setOnMouseClicked(event -> {
+
+        items.setOnMousePressed(event -> {
             getSelectionModel().select(items.getSelectionModel().getSelectedItem());
             removeListPopup.run();
         });

--- a/src/main/java/com/jayfella/jme/jfx/jmealternatives/package-info.java
+++ b/src/main/java/com/jayfella/jme/jfx/jmealternatives/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package contains drop in replacements for core JavaFX controls which would otherwise not work
+ * in JME.
+ */
+package com.jayfella.jme.jfx.jmealternatives;


### PR DESCRIPTION
The JavaFx comboBox doesn't work properly in JME because it used a separate floating window to display the list, which is outside of JMEs world. This ComboBoxJME will work in JME world.

It isn't feature complete with the core ComboBox but fulfils basic requirements (and is a lot better than the completely broken core ComboBox in JME)